### PR TITLE
Clarify document purpose as a problem statement (per David Schinazi's review)

### DIFF
--- a/draft-ietf-mops-network-overlay-impacts.md
+++ b/draft-ietf-mops-network-overlay-impacts.md
@@ -63,7 +63,7 @@ However, as consumer devices and services increasingly incorporate privacy-enhan
 
 The authors acknowledge the many challenges of improving Internet privacy while supporting the vast variety of Internet applications and use cases. This is difficult work, and it is natural that operational considerations must be carefully incorporated into architectural designs.
 
-This document is intended to highlight the negative impacts that have been observed by streaming platforms, from an operational perspective, when privacy-enhancing overlays or other network policy changes are deployed. It aims to provide insights to application developers, platform architects, and network operators into how such overlays may affect streaming video delivery.
+The purpose of this document is to raise awareness of these operational impacts. It is a problem statement that documents the negative effects streaming platforms have observed, from an operational perspective, when privacy-enhancing overlays or other network policy changes are deployed. It aims to give application developers, platform architects, network operators, and designers of privacy-enhancing technologies a shared understanding of how such overlays can affect streaming video delivery, so that these considerations can be taken into account. Defining specific mitigations is out of scope and is left to future work.
 
 # Internet Privacy Enhancements
 


### PR DESCRIPTION
Addresses David Schinazi's review of -03 on the MOPS list (2026-02-23), specifically his question about the document's call to action and target audience:

> I'm not entirely sure what the call for action is. Is the target audience video streaming operators? ... If the target audience is designers of the privacy tech, what action are they supposed to take? Right now, I feel like you identify real issues but then just leave the reader thinking "oh well, that's a shame".

Per Glenn's framing that this document is a problem statement intended to raise awareness, this rewrites the closing Introduction paragraph to state the purpose plainly (raise awareness; problem statement), name the audiences including designers of privacy-enhancing technologies, and scope solution and mitigation design as out of scope and future work.

This PR addresses only the call-to-action and purpose point. Other items from David's review are not part of this PR and are being considered separately.
